### PR TITLE
Fix summary notification count

### DIFF
--- a/vector/src/main/java/im/vector/app/features/notifications/SummaryGroupMessageCreator.kt
+++ b/vector/src/main/java/im/vector/app/features/notifications/SummaryGroupMessageCreator.kt
@@ -55,8 +55,8 @@ class SummaryGroupMessageCreator @Inject constructor(
                 ?: invitationNotifications.lastOrNull()?.timestamp
                 ?: simpleNotifications.last().timestamp
 
-        // FIXME roomIdToEventMap.size is not correct, this is the number of rooms
-        val nbEvents = roomNotifications.size + simpleNotifications.size
+        // Count each message event individually instead of counting the rooms only
+        val nbEvents = messageCount + invitationNotifications.size + simpleNotifications.size
         val sumTitle = stringProvider.getQuantityString(CommonPlurals.notification_compat_summary_title, nbEvents, nbEvents)
         summaryInboxStyle.setBigContentTitle(sumTitle)
                 // TODO get latest event?

--- a/vector/src/test/java/im/vector/app/features/notifications/SummaryGroupMessageCreatorTest.kt
+++ b/vector/src/test/java/im/vector/app/features/notifications/SummaryGroupMessageCreatorTest.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2024 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package im.vector.app.features.notifications
+
+import im.vector.app.test.fakes.FakeNotificationUtils
+import im.vector.app.test.fakes.FakeStringProvider
+import im.vector.lib.strings.CommonPlurals
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Test
+
+class SummaryGroupMessageCreatorTest {
+
+    private val stringProvider = FakeStringProvider()
+    private val notificationUtils = FakeNotificationUtils()
+
+    private val creator = SummaryGroupMessageCreator(
+            stringProvider.instance,
+            notificationUtils.instance,
+    )
+
+    @Test
+    fun `summary title uses total notification count`() {
+        val expectedNotification = notificationUtils.givenBuildSummaryListNotification()
+        val roomMeta = RoomNotification.Message.Meta(
+                summaryLine = "room",
+                messageCount = 2,
+                latestTimestamp = 123L,
+                roomId = "room-id",
+                shouldBing = false
+        )
+        val simpleMeta = OneShotNotification.Append.Meta(
+                key = "simple",
+                summaryLine = "simple",
+                isNoisy = false,
+                timestamp = 456L,
+        )
+
+        val result = creator.createSummaryNotification(
+                roomNotifications = listOf(roomMeta),
+                invitationNotifications = emptyList(),
+                simpleNotifications = listOf(simpleMeta),
+                useCompleteNotificationFormat = true,
+        )
+
+        val expectedNbEvents = 3
+        val expectedTitle = "test-${CommonPlurals.notification_compat_summary_title}-$expectedNbEvents"
+
+        notificationUtils.verifyBuildSummaryListNotificationCalledWith(expectedTitle)
+        result shouldBeEqualTo expectedNotification
+    }
+}
+

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeNotificationUtils.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeNotificationUtils.kt
@@ -13,6 +13,8 @@ import im.vector.app.features.notifications.NotificationUtils
 import im.vector.app.features.notifications.SimpleNotifiableEvent
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
 
 class FakeNotificationUtils {
 
@@ -28,5 +30,29 @@ class FakeNotificationUtils {
         val mockNotification = mockk<Notification>()
         every { instance.buildSimpleEventNotification(event, myUserId) } returns mockNotification
         return mockNotification
+    }
+
+    fun givenBuildSummaryListNotification(): Notification {
+        val mockNotification = mockk<Notification>()
+        every {
+            instance.buildSummaryListNotification(
+                any(),
+                any(),
+                noisy = any(),
+                lastMessageTimestamp = any()
+            )
+        } returns mockNotification
+        return mockNotification
+    }
+
+    fun verifyBuildSummaryListNotificationCalledWith(compatSummary: String) {
+        verify {
+            instance.buildSummaryListNotification(
+                any(),
+                compatSummary,
+                noisy = any(),
+                lastMessageTimestamp = any()
+            )
+        }
     }
 }


### PR DESCRIPTION
## Summary
- correct event count when building summary notifications
- allow capturing summary notifications in FakeNotificationUtils
- test SummaryGroupMessageCreator for proper event count

## Testing
- `./gradlew tasks --all` *(fails: No route to host)*